### PR TITLE
Fix math rendering in Jupyter book

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,3 +31,5 @@ html:
 parse:
   myst_enable_extensions:
     - html_image
+    - dollarmath
+    - amsmath


### PR DESCRIPTION
Fixes #82

Add configuration for rendering math in Jupyter book.

* Update `docs/_config.yml` to include `dollarmath` and `amsmath` extensions under `myst_enable_extensions` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BiAPoL/blog/issues/82?shareId=16752995-8d6c-495b-a3af-78eddef34dd1).